### PR TITLE
chore: Include all artifacts on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,7 @@ jobs:
       with:
         name: curl-msvc6-release-static
         path: |
-          builds/libcurl-vc6-x86-release-static/bin/curl.exe
-          builds/libcurl-vc6-x86-release-static/bin/curl.pdb
+          builds/libcurl-vc6-x86-release-static
 
   msvc6-release-dll:
     runs-on: windows-latest
@@ -77,9 +76,7 @@ jobs:
       with:
         name: curl-msvc6-release-dll
         path: |
-          builds/libcurl-vc6-x86-release-dll/bin/curl.exe
-          builds/libcurl-vc6-x86-release-dll/bin/curl.pdb
-          builds/libcurl-vc6-x86-release-dll/bin/libcurl.dll
+          builds/libcurl-vc6-x86-release-dll
 
   msvc6-debug-static:
     runs-on: windows-latest
@@ -106,8 +103,7 @@ jobs:
       with:
         name: curl-msvc6-debug-static
         path: |
-          builds/libcurl-vc6-x86-debug-static/bin/curl.exe
-          builds/libcurl-vc6-x86-debug-static/bin/curl.pdb
+          builds/libcurl-vc6-x86-debug-static
 
   msvc6-debug-dll:
     runs-on: windows-latest
@@ -134,6 +130,4 @@ jobs:
       with:
         name: curl-msvc6-debug-dll
         path: |
-          builds/libcurl-vc6-x86-debug-dll/bin/curl.exe
-          builds/libcurl-vc6-x86-debug-dll/bin/curl.pdb
-          builds/libcurl-vc6-x86-debug-dll/bin/libcurl_debug.dll
+          builds/libcurl-vc6-x86-debug-dll


### PR DESCRIPTION
This will include all generated files inside the `bin`, `include` and `lib` directories on the CI artifacts.